### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/marcelhaindl/imgsort/security/code-scanning/4](https://github.com/marcelhaindl/imgsort/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow, either at the root of the workflow (which applies to all jobs unless overridden) or to each job individually. The minimal required permission for this workflow is `contents: read`, since it only checks out and builds the code, runs tests, and performs linting—none of which require write access or access to issues, pull requests, or deployment environments. The best and least intrusive approach is to add the `permissions` block at the top of the file, right after the `name:` key and before the `on:` key.

**Summary of changes:**
- Add the following block after `name: Go`:
  ```yaml
  permissions:
    contents: read
  ```
- This limits the GITHUB_TOKEN used in the workflow to read-only access for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
